### PR TITLE
Extend InPostPoint entity

### DIFF
--- a/features/adding_image_to_shipping_method.feature
+++ b/features/adding_image_to_shipping_method.feature
@@ -11,7 +11,7 @@ Feature: Adding shipping method image
 
   @ui
   Scenario: Seeing shipments to export
-    When I want to modify a shipping method "InPost"
+    When I want to modify a shipping method "Inpost"
     And I upload the "image/shipping_logo.jpg" image as shipping method logo
     And I save my changes
     Then I should be notified that it has been successfully edited

--- a/features/adding_point_to_cart.feature
+++ b/features/adding_point_to_cart.feature
@@ -1,0 +1,23 @@
+@adding_point_to_cart
+Feature: Adding point to cart
+    In order to ship my order properly
+    As a Customer
+    I want to be able to add point to my cart
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Targaryen T-Shirt"
+        And the store allows shipping with "Inpost point" identified by "inpost_point"
+        And the store has a payment method "Online" with a code "Online"
+        And I am a logged in customer
+
+    @ui
+    Scenario: Successfully adding point to cart
+        Given I have product "Targaryen T-Shirt" in the cart
+        And I specified the billing address
+        When I select "Inpost point" shipping method
+        And the ajax request to select point "KRA01A" is sent
+        And I complete the addressing step
+        And I complete the payment step
+        Then I should be on the checkout summary step
+        And I should see the selected point is "KRA01A"

--- a/src/Controller/AddPointToOrderAction.php
+++ b/src/Controller/AddPointToOrderAction.php
@@ -98,6 +98,11 @@ final class AddPointToOrderAction
         }
 
         $point->setName($name);
+        $point->setHref($pointData['href']);
+        $point->setImageUrl($pointData['image_url']);
+        $point->setAddressLine1($pointData['address']['line1']);
+        $point->setAddressLine2($pointData['address']['line2']);
+        $point->setLocationDescription($pointData['location_description']);
 
         $order->setPoint($point);
 

--- a/src/Entity/InPostPoint.php
+++ b/src/Entity/InPostPoint.php
@@ -16,6 +16,16 @@ class InPostPoint implements InPostPointInterface
 
     private ?string $name;
 
+    private ?string $href;
+
+    private ?string $imageUrl;
+
+    private ?string $addressLine1;
+
+    private ?string $addressLine2;
+
+    private ?string $locationDescription;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -29,5 +39,55 @@ class InPostPoint implements InPostPointInterface
     public function setName(?string $name): void
     {
         $this->name = $name;
+    }
+
+    public function getHref(): ?string
+    {
+        return $this->href;
+    }
+
+    public function setHref(?string $href): void
+    {
+        $this->href = $href;
+    }
+
+    public function getImageUrl(): ?string
+    {
+        return $this->imageUrl;
+    }
+
+    public function setImageUrl(?string $imageUrl): void
+    {
+        $this->imageUrl = $imageUrl;
+    }
+    
+    public function getAddressLine1(): ?string
+    {
+        return $this->addressLine1;
+    }
+
+    public function setAddressLine1(?string $addressLine1): void
+    {
+        $this->addressLine1 = $addressLine1;
+    }
+    
+    public function getAddressLine2(): ?string
+    {
+        return $this->addressLine2;
+    }
+
+    public function setAddressLine2(?string $addressLine2): void
+    {
+        $this->addressLine2 = $addressLine2;
+    }
+
+    public function getLocationDescription(): ?string
+    {
+        return $this->locationDescription;
+    }
+
+    public function setLocationDescription(?string $locationDescription): void
+    {
+        $this->locationDescription = $locationDescription;
     }
 }

--- a/src/Entity/InPostPointInterface.php
+++ b/src/Entity/InPostPointInterface.php
@@ -17,4 +17,24 @@ interface InPostPointInterface extends ResourceInterface
     public function getName(): ?string;
 
     public function setName(?string $name): void;
+
+    public function getHref(): ?string;
+
+    public function setHref(?string $href): void;
+    
+    public function getImageUrl(): ?string;
+
+    public function setImageUrl(?string $imageUrl): void;
+    
+    public function getAddressLine1(): ?string;
+
+    public function setAddressLine1(?string $addressLine1): void;
+    
+    public function getAddressLine2(): ?string;
+
+    public function setAddressLine2(?string $addressLine2): void;
+
+    public function getLocationDescription(): ?string;
+
+    public function setLocationDescription(?string $locationDescription): void;
 }

--- a/src/Resources/assets/common/js/geowidget/GeoWidgetPreview.js
+++ b/src/Resources/assets/common/js/geowidget/GeoWidgetPreview.js
@@ -36,7 +36,7 @@ export class GeoWidgetPreview {
             'beforeend',
             `
             <img src="${data.image_url}" class="bb-inpost-point-img"/>
-            <div class="bb-inpost-point-desc" ${DEFAULT_SELECTORS.previewRaw}>
+            <div class="bb-inpost-point-desc" ${DEFAULT_SELECTORS.previewRaw} ${DEFAULT_SELECTORS.testPointPatter.replace('%point_name%', data.name)}>
                 <b>
                     ${data.name}
                 </b>

--- a/src/Resources/assets/common/js/geowidget/config.js
+++ b/src/Resources/assets/common/js/geowidget/config.js
@@ -5,6 +5,7 @@ const DEFAULT_SELECTORS = {
     wrapper: '[data-bb-event="preview-inpost-point"]',
     preview: '[data-bb-inpost-preview]',
     previewRaw: 'data-bb-inpost-preview',
+    testPointPatter: 'data-test-point-name="%point_name%"'
 };
 
 const DEFAULT_EASYPACK_CONFIG = {

--- a/src/Resources/assets/shop/js/inpostPointEvents.js
+++ b/src/Resources/assets/shop/js/inpostPointEvents.js
@@ -32,7 +32,7 @@ export class InpostPointEvents {
                     );
                 });
 
-                if (!validateNextBtn) {
+                if (!this.finalConfig.validateNextBtn) {
                     return;
                 }
 

--- a/src/Resources/config/doctrine/InPostPoint.orm.xml
+++ b/src/Resources/config/doctrine/InPostPoint.orm.xml
@@ -13,6 +13,16 @@
 
         <field name="name" column="name" type="string" />
 
+        <field name="href" column="href" type="string" />
+
+        <field name="imageUrl" column="image_url" type="string" nullable="true" />
+
+        <field name="addressLine1" column="address_line1" type="string" nullable="true" />
+
+        <field name="addressLine2" column="address_line2" type="string" nullable="true" />
+
+        <field name="locationDescription" column="location_description" type="string" nullable="true" />
+
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Resources/views/InPostGeowidgetPreview.html.twig
+++ b/src/Resources/views/InPostGeowidgetPreview.html.twig
@@ -1,13 +1,33 @@
 {% if order %}
     <div
         id="{{ wrapperId|default() ?: "order_#{ order.id }_point_details"}}"
-        class="bb-inpost-point-wrapper"
+        class="bb-inpost-point-wrapper" data-bb-target="inpost-geowidget-preview"
         {% if order.point.name|default(false) %}
             data-bb-event="preview-inpost-point"
             data-bb-point="{{ order.point.name }}"
         {% endif %}
     >
-        {% if not order.point %}
+        {% if order.point %}
+            {% if order.point.imageUrl is not null %}
+               <img src="{{ order.point.imageUrl }}" class="bb-inpost-point-img" />
+            {% endif %}
+            <div class="bb-inpost-point-desc" data-bb-inpost-preview="" {{ sylius_test_html_attribute('point-name ', "%s"|format(order.point.name)) }}>
+                <b>
+                    {{ order.point.name }}
+                </b>
+                <p>
+                    {% if order.point.addressLine1 is not null %}
+                        {{order.point.addressLine1 }}<br/>
+                    {% endif %}
+                    {% if order.point.addressLine2 is not null %}
+                        {{order.point.addressLine2 }}<br/>
+                    {% endif %}
+                    {% if order.point.locationDescription is not null %}
+                        <small>{{order.point.locationDescription }}<small>
+                    {% endif %}
+                </p>
+            </div>
+        {% else %}
             <b>{{ 'bitbag_sylius_inpost_plugin.ui.no_point_selected'|trans }}</b>
         {% endif %}
     </div>

--- a/tests/Application/config/services_test.yaml
+++ b/tests/Application/config/services_test.yaml
@@ -1,6 +1,6 @@
 imports:
-    - { resource: "../../Behat/Resources/services.yml" }
     - { resource: "../../../vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.xml" }
+    - { resource: "../../Behat/Resources/services.yml" }
 
 # workaround needed for strange "test.client.history" problem
 # see https://github.com/FriendsOfBehat/SymfonyExtension/issues/88

--- a/tests/Behat/Context/Ui/Shop/PointContext.php
+++ b/tests/Behat/Context/Ui/Shop/PointContext.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusInPostPlugin\Behat\Context\Ui\Shop;
+
+use Behat\Behat\Context\Context;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Tests\BitBag\SyliusInPostPlugin\Behat\Page\Shop\Checkout\CompletePageInterface;
+use Webmozart\Assert\Assert;
+
+class PointContext implements Context
+{
+    public function __construct(
+        private AbstractBrowser $client,
+        private SessionInterface $session,
+        private CompletePageInterface $completePage,
+    ) {
+    }
+
+    /**
+     * @When the ajax request to select point :name is sent
+     */
+    public function theAjaxRequestToSelectPointIsSent(string $name)
+    {
+        $this->client->getCookieJar()->set(new Cookie($this->session->getName(), $this->session->getId()));
+        $this->client->request(
+            'GET',
+            '/point',
+            ['name' => $name],
+            [],
+            ['ACCEPT' => 'application/json'],
+        );
+    }
+
+    /**
+     * @Then I should see the selected point is :name
+     */
+    public function iShouldSeeTheSelectedPoint(string $name)
+    {
+        Assert::true($this->completePage->hasPointName($name));
+    }
+}

--- a/tests/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/tests/Behat/Page/Shop/Checkout/AddressPage.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusInPostPlugin\Behat\Page\Shop\Checkout;
+
+use Sylius\Behat\Page\Shop\Checkout\AddressPage as BaseAddressPage;
+use Sylius\Behat\Page\Shop\Checkout\AddressPageInterface;
+use Sylius\Behat\Service\JQueryHelper;
+use Sylius\Component\Core\Model\AddressInterface;
+use Webmozart\Assert\Assert;
+
+class AddressPage extends BaseAddressPage implements AddressPageInterface
+{
+    public function specifyShippingAddress(AddressInterface $shippingAddress): void
+    {
+        $this->specifyAddress($shippingAddress, self::TYPE_SHIPPING);
+    }
+
+    public function specifyBillingAddress(AddressInterface $billingAddress): void
+    {
+        $this->specifyAddress($billingAddress, self::TYPE_BILLING);
+    }
+    
+    protected function getDefinedElements(): array
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'billing_phone_number' => '[name="sylius_checkout_address[billingAddress][phoneNumber]"]',
+            'shipping_phone_number' => '[name="sylius_checkout_address[shippingAddress][phoneNumber]"]',
+        ]);
+    }
+
+    private function specifyAddress(AddressInterface $address, string $type): void
+    {
+        $this->assertAddressType($type);
+
+        $this->getElement(sprintf('%s_first_name', $type))->setValue($address->getFirstName());
+        $this->getElement(sprintf('%s_last_name', $type))->setValue($address->getLastName());
+        $this->getElement(sprintf('%s_street', $type))->setValue($address->getStreet());
+        $this->getElement(sprintf('%s_country', $type))->selectOption($address->getCountryCode() ?: 'Select');
+        $this->getElement(sprintf('%s_city', $type))->setValue($address->getCity());
+        $this->getElement(sprintf('%s_postcode', $type))->setValue($address->getPostcode());
+
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
+
+        if (null !== $address->getPhoneNumber()) {
+            $this->getElement(sprintf('%s_phone_number', $type))->setValue($address->getPhoneNumber());
+        }
+
+        if (null !== $address->getProvinceName()) {
+            $this->waitForElement(5, sprintf('%s_province', $type));
+            $this->getElement(sprintf('%s_province', $type))->setValue($address->getProvinceName());
+        }
+        if (null !== $address->getProvinceCode()) {
+            $this->waitForElement(5, sprintf('%s_country_province', $type));
+            $this->getElement(sprintf('%s_country_province', $type))->selectOption($address->getProvinceCode());
+        }
+    }
+
+    private function waitForElement(int $timeout, string $elementName): bool
+    {
+        return $this->getDocument()->waitFor($timeout, fn () => $this->hasElement($elementName));
+    }
+
+    private function assertAddressType(string $type): void
+    {
+        $availableTypes = [self::TYPE_BILLING, self::TYPE_SHIPPING];
+
+        Assert::oneOf($type, $availableTypes, sprintf('There are only two available types %s, %s. %s given', self::TYPE_BILLING, self::TYPE_SHIPPING, $type));
+    }
+}

--- a/tests/Behat/Page/Shop/Checkout/CompletePage.php
+++ b/tests/Behat/Page/Shop/Checkout/CompletePage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusInPostPlugin\Behat\Page\Shop\Checkout;
+
+use Sylius\Behat\Page\Shop\Checkout\CompletePage as BaseCompletePage;
+
+class CompletePage extends BaseCompletePage implements CompletePageInterface
+{
+    public function hasPointName(string $pointName): bool
+    {
+        return $this->hasElement('point_name', ['%pointName%' => $pointName]);
+    }
+
+    protected function getDefinedElements(): array
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'point_name' => '[data-test-point-name="%pointName%"]',
+        ]);
+    }
+}

--- a/tests/Behat/Page/Shop/Checkout/CompletePageInterface.php
+++ b/tests/Behat/Page/Shop/Checkout/CompletePageInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusInPostPlugin\Behat\Page\Shop\Checkout;
+
+use Sylius\Behat\Page\Shop\Checkout\CompletePageInterface as BaseCompletePageInterface;
+
+interface CompletePageInterface extends BaseCompletePageInterface
+{
+    public function hasPointName(string $pointName): bool;
+}

--- a/tests/Behat/Resources/services.yml
+++ b/tests/Behat/Resources/services.yml
@@ -1,3 +1,7 @@
+parameters:
+    sylius.behat.page.shop.checkout.address.class: 'Tests\BitBag\SyliusInPostPlugin\Behat\Page\Shop\Checkout\AddressPage'
+    sylius.behat.page.shop.checkout.complete.class: 'Tests\BitBag\SyliusInPostPlugin\Behat\Page\Shop\Checkout\CompletePage'
+
 imports:
     - { resource: "services/**/*.yml" }
     - { resource: "../../../vendor/bitbag/shipping-export-plugin/tests/Behat/Resources/services.yml" }

--- a/tests/Behat/Resources/services/contexts.yml
+++ b/tests/Behat/Resources/services/contexts.yml
@@ -30,3 +30,10 @@ services:
         arguments:
             - '@bitbag.sylius_inpost_plugin.behat.page.admin.shipping_method.update'
 
+    bitbag.sylius_inpost_plugin.behat.context.ui.shop.point:
+        class: Tests\BitBag\SyliusInPostPlugin\Behat\Context\Ui\Shop\PointContext
+        public: true
+        arguments:
+            - '@test.client'
+            - '@session'
+            - '@sylius.behat.page.shop.checkout.complete'

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -1,5 +1,27 @@
 default:
     suites:
+        adding_point_to_cart:
+            contexts:
+                - sylius.behat.context.hook.doctrine_orm
+
+                - sylius.behat.context.transform.product
+
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.payment
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.shop_security
+                - sylius.behat.context.setup.shipping
+
+                - sylius.behat.context.ui.shop.cart
+                - sylius.behat.context.ui.shop.checkout.addressing
+                - sylius.behat.context.ui.shop.checkout.complete
+                - sylius.behat.context.ui.shop.checkout.payment
+                - sylius.behat.context.ui.shop.checkout.shipping
+
+                - bitbag.sylius_inpost_plugin.behat.context.ui.shop.point
+            filters:
+                tags: "@adding_point_to_cart&&@ui"
+
         managing_shipping_gateway_inpost:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm


### PR DESCRIPTION
- [x] Extend InPostPoint entity to store more point details locally.
- [x] Use data from db to display point on checkout confirmation step.
- [x] Create "Adding point to cart" feature with basic scenario testing if point was assigned to the cart.
- [x] Fix some 1.4.0 version issues.